### PR TITLE
chore: fix params in bundle example

### DIFF
--- a/examples/bundle/src/cli.ts
+++ b/examples/bundle/src/cli.ts
@@ -1,7 +1,8 @@
 import { program, command } from 'bandersnatch'
 
 export default program().default(
-  command('echo', 'Echo something in the terminal')
-    .argument('words', 'Say some kind words', { variadic: true })
+  command('echo')
+    .description('Echo something in the terminal')
+    .argument('words', { description: 'Say some kind words', variadic: true })
     .action(console.log)
 )


### PR DESCRIPTION
It seems that this example has not been updated to the latest API interface.