### PR TITLE
fix: stop and restart repl to allow enquirer prompt

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   testMatch: ['**/*.spec.ts'],
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json'
     }
   },
   setupFiles: ['./jest.setup.js']

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,7 +1,7 @@
-import { Argv, CommandModule, Arguments as BaseArguments } from 'yargs'
+import { Arguments as BaseArguments, Argv, CommandModule } from 'yargs'
 import { Argument, ArgumentOptions } from './argument'
-import { Option, OptionOptions } from './option'
 import { InferArgType } from './baseArg'
+import { Option, OptionOptions } from './option'
 import { prompter } from './prompter'
 
 export type Arguments<T = {}> = T &
@@ -279,7 +279,7 @@ export class Command<T = {}> {
           return this.handler(args, commandRunner)
         }
 
-        // Display help this command contains sub-commands
+        // Display help if this command contains sub-commands
         if (this.getCommands().length) {
           return commandRunner(`${this.getFqn()} --help`)
         }

--- a/src/program.ts
+++ b/src/program.ts
@@ -2,9 +2,8 @@ import { EventEmitter } from 'events'
 import TypedEventEmitter from 'typed-emitter'
 import { Argv } from 'yargs'
 import createYargs from 'yargs/yargs'
-import { Command, command } from './command'
+import { Arguments, Command, command } from './command'
 import { Repl, repl } from './repl'
-import { Arguments } from './command'
 import { isPromise } from './utils'
 
 interface Events {

--- a/src/prompter.ts
+++ b/src/prompter.ts
@@ -18,7 +18,7 @@ type PromptType =
 type Question = any
 
 /**
- * Creates a new command, which can be added to a program.
+ * Creates a new prompter instance
  */
 export function prompter<T = {}>(baseArgs: Array<Argument | Option>, args: T) {
   return new Prompter(baseArgs, args)

--- a/tests/program.spec.ts
+++ b/tests/program.spec.ts
@@ -1,6 +1,33 @@
 // @ts-ignore
 import mockArgv from 'mock-argv'
-import { program, Program, command } from '../src'
+import { mocked } from 'ts-jest/utils'
+import { command, program, Program, Repl } from '../src'
+
+jest.mock('../src/repl', () => {
+  return {
+    repl: jest.fn().mockImplementation(() => {
+      return new MockedRepl()
+    }),
+    Repl: jest.fn().mockImplementation(() => {
+      return MockedRepl
+    }),
+  }
+})
+
+// Repl mock
+const replStartFn = jest.fn()
+const replPauseFn = jest.fn()
+const replResumeFn = jest.fn()
+class MockedRepl {
+  start = replStartFn
+  pause = replPauseFn
+  resume = replResumeFn
+}
+
+beforeEach(() => {
+  const MockedRepl = mocked(Repl, true)
+  MockedRepl.mockClear()
+})
 
 test('program should return new Program object', () => {
   expect(program()).toBeInstanceOf(Program)
@@ -24,4 +51,10 @@ test('program executes argv', async () => {
     )
     await expect(app.run()).resolves.toBe('foo')
   })
+})
+
+test('program starts repl', async () => {
+  const app = program()
+  expect(app.repl()).toBeInstanceOf(MockedRepl)
+  expect(replStartFn).toHaveBeenCalled()
 })


### PR DESCRIPTION
When a command is ran from the REPL server, prompt inputs where passed to the servers `eval` function. Work around this by stopping the server on executing a command, and restarting it afterwards. Also fixes a bug with disappearing cursor from what I suspect is [a bug in enquirer](https://github.com/enquirer/enquirer/issues/116).