### PR TITLE
feat: allow custom exit command implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ Creates a new program. Options (object, optional) can contain these keys:
   program which displays program version from package.json.
 - `historyFile` (string | null, defaults: {homedir}/.bandersnatch_history) is a
   path to the app history file. Set to NULL to disable.
+- `exit` (boolean | () => void, default: () => process.exit()) Specifies whether to add a default behaviour for an `exit`
+  command. `false` disables the default implementation, a custom function will be installed
+  as the actual handler.
 
 #### `program.description(description)`
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -98,6 +98,11 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
       this.options.historyFile = path.join(os.homedir(), DEFAULT_HISTORY_FILE)
     }
 
+    // Set default exit handler
+    if (this.options.exit && typeof this.options.exit !== 'function') {
+      this.options.exit = () => process.exit()
+    }
+
     if (this.options.historyFile !== null) {
       this.history = history(this)
     }

--- a/src/program.ts
+++ b/src/program.ts
@@ -57,6 +57,15 @@ type ProgramOptions = {
   historyFile?: string | null
 }
 
+type ReplOptions = {
+  /**
+   * Specifies whether to add a default behaviour for an `exit` command.
+   * 
+   * Defaults to `true`.
+   */
+  addExitCommand?: boolean;
+}
+
 /**
  * Creates a new bandersnatch program.
  */
@@ -223,17 +232,23 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
   /**
    * Run event loop which reads command from stdin.
    */
-  public repl() {
+  public repl(options: ReplOptions) {
+    if (typeof options.addExitCommand === 'undefined') {
+      options.addExitCommand = true
+    }
+
     this.replInstance = repl(this)
 
     // Add exit command
-    this.add(
-      command('exit')
-        .description('Exit the application')
-        .action(() => {
-          process.exit()
-        })
-    )
+    if (options.addExitCommand) {
+      this.add(
+        command('exit')
+          .description('Exit the application')
+          .action(() => {
+            process.exit()
+          })
+      )
+    }
 
     if (this.history) {
       this.replInstance.attachHistory(this.history)

--- a/src/program.ts
+++ b/src/program.ts
@@ -261,8 +261,8 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
   /**
    * When argv is set, run the program, otherwise start repl loop.
    */
-  public runOrRepl() {
-    return extractCommandFromProcess().length ? this.run() : this.repl()
+  public runOrRepl(options: ReplOptions) {
+    return extractCommandFromProcess().length ? this.run() : this.repl(options)
   }
 
   /**

--- a/src/program.ts
+++ b/src/program.ts
@@ -99,7 +99,7 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
     }
 
     // Set default exit handler
-    if (this.options.exit && typeof this.options.exit !== 'function') {
+    if (this.options.exit === true || typeof this.options.exit === 'undefined') {
       this.options.exit = () => process.exit()
     }
 


### PR DESCRIPTION
I'm creating a CLI which runs in an async context with init and dispose hooks. Just calling `process.exit()` when the user types `exit` may be fatal.

This change allows for custom implementation for an `exit` command.