### PR TITLE
feat: do not print errors returned from yargs

### DIFF
--- a/examples/cat.ts
+++ b/examples/cat.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs'
+import { command, program } from '../src'
+
+const cat = command('cat')
+  .description('Concatenate files')
+  .argument('files', { variadic: true })
+  .action(({ files }) =>
+    console.log(
+      files.reduce((str, file) => str + readFileSync(file, 'utf8'), '')
+    )
+  )
+
+program()
+  .default(cat)
+  .run()
+  .catch((err) => {
+    console.error(`There was a problem running this command:\n${String(err)}`)
+    process.exit(1)
+  })

--- a/examples/errors.ts
+++ b/examples/errors.ts
@@ -1,4 +1,4 @@
-import { program, command } from '../src'
+import { command, program } from '../src'
 
 const app = program()
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -58,12 +58,12 @@ type ProgramOptions = {
 
   /**
    * Specifies whether to add a default behaviour for an `exit` command.
-   * 
+   *
    * Takes a boolean or a function argument:
    * - `false` installs no handler
    * - `true` will install the default handler
    * - a given function will be installed as the handler
-   * 
+   *
    * Defaults to `() => process.exit()`.
    */
   exit?: boolean | (() => void)
@@ -99,7 +99,10 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
     }
 
     // Set default exit handler
-    if (this.options.exit === true || typeof this.options.exit === 'undefined') {
+    if (
+      this.options.exit === true ||
+      typeof this.options.exit === 'undefined'
+    ) {
       this.options.exit = () => process.exit()
     }
 
@@ -217,9 +220,12 @@ export class Program extends (EventEmitter as new () => TypedEventEmitter<Events
            * From the yargs docs:
            * > Populated if any validation errors raised while parsing.
            * http://yargs.js.org/docs/#api-parseargs-context-parsecallback
+           * This seems to be incorrect though, and err is populated when any
+           * error is thrown inside the command handler.
            */
           if (err) {
-            console.error(err)
+            // Ignore err value, which encourages users to deliberately handle
+            // error conditions in their programs.
           }
 
           if (isPromise(argv.__promise)) {


### PR DESCRIPTION
This PR removes the `console.error` which would print errors returned from yargs. It was expected only validation errors would be returned, but it turns out any thrown error from command handlers is returned as the err parameter in the `parse` callback function.

Also adds an example to the readme to explain error handling better.

Fixes #284 