### PR TITLE
chore: fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ Install dependencies:
 
 ```
 yarn add bandersnatch
-yarn add typescript pkg --dev
+yarn add typescript @types/node pkg --dev
 ```
 
 And create an example app in `src/cli.ts`:
@@ -610,8 +610,9 @@ And create an example app in `src/cli.ts`:
 import { program, command } from 'bandersnatch'
 
 export default program().default(
-  command('echo', 'Echo something in the terminal')
-    .argument('words', 'Say some kind words', { variadic: true })
+  command('echo')
+    .description('Echo something in the terminal')
+    .argument('words', { description: 'Say some kind words', variadic: true })
     .action(console.log)
 )
 ```


### PR DESCRIPTION
I needed to make the following changes to the instructions in order to get the `yarn build` step to work:
1. include `@types/node` to the **yarn add** command
2. use the same code for`src/cli.ts` as in `examples/bundle/src/cli.ts` 

Without `@types/node` I observe a compile error:
node_modules/bandersnatch/lib/types/history.d.ts:1:23 - error TS2688: Cannot find type definition file for 'node'. /// <reference types="node" />

Without updating `src/cli.ts` to match the example from the bundle directory I observe a compile error:
src/cli.ts:5:47 - error TS2554: Expected 1-2 arguments, but got 3.
    .argument('words', 'Say some kind words', { variadic: true })

With these changes the **yarn build** step worked for me.