### PR TITLE
feat: update node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18
+          - 20
           - 22
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Automated changes by [update-node-versions](https://github.com/hongaar/update-node-versions) GitHub action

BREAKING CHANGE: This updates the supported node.js versions