### PR TITLE
Add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "option"
   ],
   "repository": "github:hongaar/bandersnatch",
+  "homepage": "https://github.com/hongaar/bandersnatch#readme",
+  "bugs": {
+    "url": "https://github.com/hongaar/bandersnatch/issues"
+  },
   "license": "MIT",
   "author": "Joram van den Boezem <joram@vandenboezem.nl>",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

Adds standard npm metadata links for the published `bandersnatch` package:

- `homepage`: `https://github.com/hongaar/bandersnatch#readme`
- `bugs.url`: `https://github.com/hongaar/bandersnatch/issues`

The package already exposes `repository` as `github:hongaar/bandersnatch`; this PR keeps the change limited to package metadata.

## Verification

- `npm view bandersnatch@2.0.1 name version homepage repository bugs deprecated --json` shows the published package currently exposes `repository` but not `homepage` or `bugs`.
- Metadata smoke check for `repository` / `homepage` / `bugs.url` passed.
- `npm pack --dry-run --ignore-scripts` passed.
- `npx -p @yarnpkg/cli-dist@3.5.0 yarn install --immutable` passed with an existing TypeScript patch warning.
- `npx -p @yarnpkg/cli-dist@3.5.0 yarn build` passed.
- `git diff --check` passed.

Known existing local checks:

- `yarn test` fails on the current baseline and this branch at `tests/unit/autocomplete.spec.ts`, expecting `test` while receiving `test:`.
- `yarn format:check` reports existing `CHANGELOG.md` formatting.
